### PR TITLE
Oprional original file keeping implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,15 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - `.env` file support
 - Global `--version` flag
 - `--update-mod-date` flag for `compress` sub-command (since this release, the original file modification date will be preserved by default)
+- `--keep-original-file` flag for `compress` sub-command [#103]
 
 ### Removed
 
 - Sub-command `version` (you can use `--version` flag instead)
 - Global `--debug` flag
 - Global `--verbose` flag
+
+[#103]:https://github.com/tarampampam/tinifier/issues/103
 
 ## v3.5.0
 


### PR DESCRIPTION
## Description

### Added

- `--keep-original-file` flag for `compress` sub-command

Related issue #103

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [x] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
